### PR TITLE
HFP-4252 Fix AV-widget not allowing to add multiple videos

### DIFF
--- a/scripts/h5peditor-av.js
+++ b/scripts/h5peditor-av.js
@@ -319,7 +319,7 @@ H5PEditor.widgets.video = H5PEditor.widgets.audio = H5PEditor.AV = (function ($)
     var qualityName = (file.metadata && file.metadata.qualityName) ? file.metadata.qualityName : defaultQualityName;
 
     // Check if source is provider (Vimeo, YouTube, Panopto)
-    const isProvider = file.path && C.findProvider(file.path);
+    const isProvider = (file.path && C.findProvider(file.path)) ?? false;
 
     // Only allow single source if YouTube
     if (isProvider) {


### PR DESCRIPTION
When merged in, fixes the AV widget not showing another upload button after the upload process of a video has completed.